### PR TITLE
JS cleanup, destroy chaining, py2 requirements, autobahn fix

### DIFF
--- a/documentation/content/docs/tools.md
+++ b/documentation/content/docs/tools.md
@@ -86,3 +86,41 @@ Windows/Linux or Ctrl + ⌥ + f on Mac. Alternatively, use the context menu.
 ### EditorConfig
 
 [More information available here](https://github.com/sindresorhus/editorconfig-sublime#readme)
+
+## Releases
+
+### Python
+
+wslink is published to [pypi](https://pypi.python.org/pypi/wslink). The basic
+steps taken by the maintainer to publish:
+
+* Update version in `python/src/wslink/__init__.py`
+* run tests
+* `cd python/`
+* `pip install -U requirements-dev.txt`
+* `rm dist/*`
+* `python setup.py bdist_wheel sdist`
+* `twine upload dist/*`
+
+### JavaScript
+
+wslink is published to [npm](https://www.npmjs.com/package/wslink). This can
+potentially be handled automatically by SemanticRelease, but we are not using
+that tool (yet?) because we want to synchronize with the python release.
+
+* `cd js/`
+* `npm run build:release`
+* `npm run build:example`
+* `npm publish`
+
+### Documentation
+
+wslink's webpage is on [Github Pages](https://kitware.github.io/wslink/) and is
+generated using [kw-doc](https://github.com/Kitware/kw-doc). It should be
+automatically updated by Travis-CI when a commit is made to the master branch.
+This is not working currently. Steps to update:
+
+* `cd js/`
+* `npm run doc:www`
+    * test the docs locally
+* `npm run doc:publish`

--- a/js/examples/main.js
+++ b/js/examples/main.js
@@ -92,10 +92,13 @@ export function toggleStream() {
 export function wsclose() {
   if (!session) return;
   session.close();
+  // it's fine to destroy the WebsocketConnection, but you won't get the WS close message.
+  // if (ws) ws.destroy();
+  // ws = null;
 }
 
 export function connect(direct=false) {
-  let ws = null;
+  ws = null;
   if (direct) {
     ws = WebsocketConnection.newInstance({ urls: 'ws://localhost:8080/ws' });
   } else {

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wslink",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Rpc and pub/sub between Python and JavaScript over WebSockets",
   "repository": {
     "type": "git",

--- a/js/src/ProcessLauncher/index.js
+++ b/js/src/ProcessLauncher/index.js
@@ -4,10 +4,6 @@ import CompositeClosureHelper from '../CompositeClosureHelper';
 const connections = [];
 
 function ProcessLauncher(publicAPI, model) {
-// export default class ProcessLauncher {
-//   constructor(endPoint) {
-//     model.endPoint = endPoint;
-//   }
 
   publicAPI.start = (config) => {
     var xhr = new XMLHttpRequest(),
@@ -82,7 +78,6 @@ function ProcessLauncher(publicAPI, model) {
     xhr.send();
   }
 
-  /* eslint-disable class-methods-use-this */
   publicAPI.listConnections = () => {
     return connections;
   }

--- a/js/src/SmartConnect/index.js
+++ b/js/src/SmartConnect/index.js
@@ -64,7 +64,7 @@ function smartConnect(publicAPI, model) {
     return session;
   };
 
-  publicAPI.destroy = () => {
+  function cleanUp() {
     if (session) {
       session.close();
     }
@@ -73,7 +73,9 @@ function smartConnect(publicAPI, model) {
     while (model.gc.length) {
       model.gc.pop().destroy();
     }
-  };
+  }
+
+  publicAPI.destroy = CompositeClosureHelper.chain(cleanUp, publicAPI.destroy);
 }
 
 const DEFAULT_VALUES = {

--- a/js/src/WebsocketConnection/index.js
+++ b/js/src/WebsocketConnection/index.js
@@ -96,16 +96,17 @@ function WebsocketConnection(publicAPI, model) {
 
   publicAPI.getUrl = () => (model.connection ? model.connection.url : undefined);
 
-  publicAPI.destroy = (timeout = 10) => {
-    // publicAPI.off();
+  function cleanUp(timeout = 10) {
     if (model.session && timeout > 0) {
-      // model.session.call('application.exit.later', [timeout]);
+      model.session.call('application.exit.later', [timeout]);
     }
     if (model.connection) {
       model.connection.close();
     }
     model.connection = null;
-  };
+  }
+
+  publicAPI.destroy = CompositeClosureHelper.chain(cleanUp, publicAPI.destroy);
 }
 
 const DEFAULT_VALUES = {

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,4 +2,4 @@ autobahn==0.18.1
 twisted==17.1.0
 
 # platform specific
-pypiwin32==220; sys_platform == 'win32'
+pypiwin32; sys_platform == 'win32'

--- a/python/src/wslink/websocket.py
+++ b/python/src/wslink/websocket.py
@@ -148,10 +148,6 @@ class TimeoutWebSocketServerFactory(WebSocketServerFactory):
         WebSocketServerFactory.__init__(self, *args, **kwargs)
         WebSocketServerFactory.protocol = TimeoutWebSocketServerProtocol
 
-    def startFactory(self):
-        # this is only called if the WsSite factory isn't created first.
-        log.msg("wslink: Starting factory", logLevel=logging.CRITICAL)
-
     def connectionMade(self):
         if self._reaper:
             log.msg("Client has reconnected, cancelling reaper", logLevel=logging.DEBUG)
@@ -175,12 +171,6 @@ class TimeoutWebSocketServerFactory(WebSocketServerFactory):
 
     def getServerProtocol(self):
         return self._protocolHandler
-
-    ### Does not seem to work to print a "ready line"
-    # def startFactory(self):
-    #     sys.stdout.write("wslink: Starting factory\n")
-    #     sys.stdout.flush()
-    #     WebSocketServerFactory.startFactory(self)
 
     def getClientCount(self):
         return self.clientCount
@@ -212,6 +202,7 @@ CLIENT_ERROR = -32099
 
 class WslinkWebSocketServerProtocol(TimeoutWebSocketServerProtocol):
     def __init__(self):
+        super(WslinkWebSocketServerProtocol, self).__init__()
         self.functionMap = {}
         self.attachmentMap = {}
         self.attachmentId = 0


### PR DESCRIPTION
Cleanup comments and example in js - with commented test for
WebsocketConnection.destroy()
Chain .destroy() calls, so default .destroy() is also called.
Remove extra "Starting factory" message which isn't needed.

Python:
py2.7 pypiwin32 has different version - use any version in requirements.txt

Add back super().__init__() call, to fix exception when using current Autobahn -
one of the parent classes has an __init__() which needs to be called.
Old autobahn from VTK still works because multiple inheritance from 'object'
ensures that the super() call works on py2.