### PR TITLE
fix(session): support RPC with just a binary attachment result.

### DIFF
--- a/js/src/CompositeClosureHelper/index.js
+++ b/js/src/CompositeClosureHelper/index.js
@@ -234,6 +234,7 @@ function chain(...fn) {
 //     - fireMutualInformationSubscriptionChange(request)
 //     - subscribeToMutualInformation(onDataReady, variables = [], metadata = {})
 //     - setMutualInformation(data)
+//     - hasMutualInformation(request, variable)
 //     - destroy()
 // ----------------------------------------------------------------------------
 
@@ -326,6 +327,23 @@ function dataSubscriber(publicAPI, model, dataName, dataHandler) {
       dataSubscriptions.forEach(dataListener => flushDataToListener(dataListener, data));
     }
   };
+  // Retrieve data for a single variable from our cache, given current request.
+  // Call from inside on{dataName}SubscriptionChange to find out if
+  // cache needs to be updated.
+  publicAPI[`has${capitalize(dataName)}`] = (inRequest, variable) => {
+    try {
+      if (inRequest) {
+        const request = Object.assign({}, inRequest, { variables: [variable] });
+        const dataToForward = dataHandler.get(model[dataContainerName], request, null);
+        if (dataToForward) {
+          return true;
+        }
+      }
+    } catch (err) {
+      console.log(`has ${dataName} error caught:`, err);
+    }
+    return false;
+  }
 
   publicAPI.destroy = chain(off, publicAPI.destroy);
 }

--- a/js/test/main.js
+++ b/js/test/main.js
@@ -11,6 +11,7 @@ const htmlContent = `<button onClick="app.connect()">Connect</button>
 <input type="text" value="1,2,3,4,5" class="input" />
 <button onClick="app.sendInput('add')">Send Add</button>
 <button onClick="app.sendInput('mult')">Send Mult</button>
+<button onClick="app.sendImage('unwrapped.image')">Send Image</button>
 <button onClick="app.testNesting()">Test Nesting</button>
 <button onClick="app.toggleStream()">Sub/Unsub</button>
 <button onClick="app.sendMistake()">Mistake</button>
@@ -48,9 +49,17 @@ export function sendInput(type) {
   session.call(`myprotocol.${type}`, [data])
     .then((result) => log('result ' + result), (err) => logerr(err));
 }
-
-function handleMessage(data) {
-  let blob = Array.isArray(data) ? data[0].blob : data.blob;
+export function sendImage(type) {
+  if (!session) return;
+  session.call(`myprotocol.${type}`, [])
+    .then((result) => {
+      log('result ' + result);
+      handleMessage(result);
+    }, (err) => logerr(err));
+}
+function handleMessage(inData) {
+  let data = Array.isArray(inData) ? inData[0] : inData;
+  let blob = data.blob || data;
   if (blob instanceof Blob) {
     const canvas = document.querySelector('.imageCanvas');
     const ctx = canvas.getContext('2d');

--- a/python/examples/myProtocol.py
+++ b/python/examples/myProtocol.py
@@ -45,6 +45,14 @@ class MyProtocol(LinkProtocol):
             contents = file.read()
             return { "blob": self.addAttachment(contents) }
 
+    @exportRPC("myprotocol.unwrapped.image")
+    def image(self, alt = False):
+        filename = "kitware.png" if not alt else "kitware2.png"
+        filename = os.path.join(os.path.dirname(__file__), filename)
+        with open(filename, mode='rb') as file:
+            contents = file.read()
+            return self.addAttachment(contents)
+
     def pushImage(self):
         print("push image", self.subMsgCount)
         msg = self.image(self.subMsgCount % 2 is 0)


### PR DESCRIPTION
Support a client doing 'return self.addAttachment(buffer)' from
an RPC method. JS must check if a result is a string representing
the binary attachment. Add a test.

CC @jourdain 