### PR TITLE
fix(deps): Add extras_require for service_identity

### DIFF
--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -9,3 +9,6 @@ collective.checkdocs
 # publishing
 twine
 wheel
+
+# TLS
+service_identity>=17.0.0

--- a/python/setup.py
+++ b/python/setup.py
@@ -55,5 +55,7 @@ setup(
     ),
     package_dir={'':'src'},
     install_requires=install_reqs,
-    # extras_require=extras_reqs,
+    extras_require={
+        'security': ['service_identity>=17.0.0'],
+    },
 )

--- a/python/src/wslink/__init__.py
+++ b/python/src/wslink/__init__.py
@@ -5,7 +5,7 @@ javascript client over a websocket.
 wslink.server creates the python server
 wslink.websocket handles the communication
 """
-__version__ = '0.1.5'
+__version__ = '0.1.6'
 __license__ = 'BSD-3-Clause'
 
 from .uri import checkURI


### PR DESCRIPTION
What do you think of adding this dependency as an extra?  Then other projects could get that installed ala:

```
pip install wslink[security]
```

See the pip [docs](https://pip.pypa.io/en/stable/reference/pip_install/#examples) for more details.  And according to [PEP508](https://www.python.org/dev/peps/pep-0508/#extras), they could also list it in their `requirements.txt` in a similar way:

```
wslink[security]
```

@aron-helser @jourdain Does this seem reasonable to you?