### PR TITLE
fix(launcher): santize potential command lines

### DIFF
--- a/python/src/wslink/__init__.py
+++ b/python/src/wslink/__init__.py
@@ -5,7 +5,7 @@ javascript client over a websocket.
 wslink.server creates the python server
 wslink.websocket handles the communication
 """
-__version__ = '0.1.7'
+__version__ = '0.1.8'
 __license__ = 'BSD-3-Clause'
 
 from .uri import checkURI


### PR DESCRIPTION
Add 'santize' key to the launcher config, so potential values
provided by the client can be compared to known values before
executing them as a process. Verify against a list or regexp.

@jourdain what do you think? Should I leave in the log.warning()?