### PR TITLE
fix(launcher.py): Don't enforce begin/end marks in sanitize regexp

### DIFF
--- a/python/src/tests/test-wslink.conf
+++ b/python/src/tests/test-wslink.conf
@@ -1,0 +1,46 @@
+{
+    // Test sanitization:
+    // cmd lines: python wslink/launcher.py tests/test-wslink.conf
+    //   curl -H "Content-Type: application/json" -X POST -d '{"application": "test","cmd":"meX","cmd2":"hello\"912"}' http://local host:9000/paraview
+    // check launcherLog.log for:
+    //   key cmd: sanitize meX with default
+    //   key cmd2: sanitize hello"912 with default
+    // and hashed .txt file in temp dir for default output:
+    //   nothing-to-do nothing
+    "configuration": {
+        "host" : "localhost",
+        "port" : 9000,
+        "endpoint": "paraview",
+        "proxy_file" : "/akit/temp/proxy-mapping.txt", //here
+        "sessionURL" : "ws://${host}:${port}/ws", // here
+        "timeout" : 25,
+        "log_dir" : "/akit/temp",
+        "upload_dir" : "/akit/temp",
+        "fields" : [],
+        "sanitize": {
+            "cmd": {
+                "type": "inList",
+                "list": [
+                    "me", "you", "something/else/altogether", "nothing-to-do"
+                ],
+                "default": "nothing-to-do"
+            },
+            "cmd2": {
+                "type": "regexp",
+                "regexp": "^[^\"]*$",
+                "default": "nothing"
+            }
+        }
+    },
+    "sessionData" : {},
+    "resources" : [ { "host" : "localhost", "port_range" : [9001, 9003] } ],
+    "properties" : {},
+    "apps" : {
+        "test" : {
+            "cmd" : [
+                "echo", "${cmd} ${cmd2}"
+            ],
+            "ready_line" : "Starting factory"
+        }
+    }
+}

--- a/python/src/wslink/__init__.py
+++ b/python/src/wslink/__init__.py
@@ -5,7 +5,7 @@ javascript client over a websocket.
 wslink.server creates the python server
 wslink.websocket handles the communication
 """
-__version__ = '0.1.8'
+__version__ = '0.1.9'
 __license__ = 'BSD-3-Clause'
 
 from .uri import checkURI


### PR DESCRIPTION
Allow JS/C++ comments in launcher config. Add comments and sample
of sanitize config. Add test config used to tests/ dir.

CC @jourdain 