### PR TITLE
fix(launcher.py): Support GET and DELETE with Python 3

### DIFF
--- a/python/src/wslink/launcher.py
+++ b/python/src/wslink/launcher.py
@@ -249,10 +249,10 @@ def filterResponse(obj, public_keys):
 # -----------------------------------------------------------------------------
 
 def extractSessionId(request):
-    path = request.path.split('/')
+    path = request.path.split(b'/')
     if len(path) < 3:
-       return None
-    return str(path[2])
+        return None
+    return str(path[2],'utf-8')
 
 def jsonResponse(payload):
     return json.dumps(payload, ensure_ascii = False).encode('utf8')


### PR DESCRIPTION
Prevents the following error when doing GET or DELETE
request:
`builtins.TypeError: a bytes-like object is required, not 'str'
`
Closes #16