### PR TITLE
Possible Memory Leak: session.inFlightRpc keeps all RPCs

### DIFF
--- a/js/src/WebsocketConnection/session.js
+++ b/js/src/WebsocketConnection/session.js
@@ -246,6 +246,7 @@ function Session(publicAPI, model) {
           }
         }
       }
+      delete inFlightRpc[payload.id];
     }
   };
 


### PR DESCRIPTION
We noticed a memory leak working with https://kitware.github.io/paraviewweb/examples/RemoteRenderer.html#Using-ParaView-as-server. In the web-browser, there are lots of strings, that are not freed. These strings contain the transmitted image data. Therefore each time a new picture is rendered, the needed memory rises (see attached screenshot).

We identified the inFlightRpc object as the culprit. This stores all RPCs, and they are never deleted. A possible solution, that did not cause any errors for us, was deleting them after they are processed.

<img width="576" alt="RpcReferenzenMarkedZoomed" src="https://user-images.githubusercontent.com/57713653/74851379-720f4280-533b-11ea-90aa-a9c1d9007f05.png">
<img width="1280" alt="memDiffMarked" src="https://user-images.githubusercontent.com/57713653/74851385-72a7d900-533b-11ea-9a7f-04144b2ad3b5.png">

