### PR TITLE
Forward the websocket close event to application callbacks

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wslink",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Rpc and pub/sub between Python and JavaScript over WebSockets",
   "repository": {
     "type": "git",

--- a/js/src/SmartConnect/api.md
+++ b/js/src/SmartConnect/api.md
@@ -20,16 +20,18 @@ Trigger the connection request.
 
 Register callback for when the connection became ready.
 
-## onConnectionClose(callback, err) : subscription
+## onConnectionClose(callback) : subscription
 
-Register callback for when the connection close.  Err is a websocket event. If
-the server closes the connection after sending a close frame
-(https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.1), the err object
-will have shape {code: number, reason: string}.
+Register callback for when the connection close.  Callback takes
+two arguments, the connection object and a websocket event.
+If the server closes the connection after sending a close frame
+(https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.1), the event
+will have the shape {code: number, reason: string}.
 
-## onConnectionError(callback, err) : subscription
+## onConnectionError(callback) : subscription
 
 Register callback for when the connection request failed.
+Callback takes two arguments, the connection object and a websocket event.
 
 ## getSession() : session
 

--- a/js/src/SmartConnect/api.md
+++ b/js/src/SmartConnect/api.md
@@ -6,13 +6,13 @@ a sessionURL is already provided in the configuration
 it will establish a direct WebSocket connection using
 Autobahn.
 
-## SmartConnect.newInstance({ config }) 
+## SmartConnect.newInstance({ config })
 
 Create an instance that will use the provided configuration to
 connect itself to a server either by requesting a new remote
 process or by trying to directly connecting to it as a fallback.
 
-## connect() 
+## connect()
 
 Trigger the connection request.
 
@@ -20,11 +20,14 @@ Trigger the connection request.
 
 Register callback for when the connection became ready.
 
-## onConnectionClose(callback) : subscription
+## onConnectionClose(callback, err) : subscription
 
-Register callback for when the connection close.
+Register callback for when the connection close.  Err is a websocket event. If
+the server closes the connection after sending a close frame
+(https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.1), the err object
+will have shape {code: number, reason: string}.
 
-## onConnectionError(callback) : subscription
+## onConnectionError(callback, err) : subscription
 
 Register callback for when the connection request failed.
 
@@ -32,6 +35,6 @@ Register callback for when the connection request failed.
 
 Return the session associated with the connection.
 
-## destroy() 
+## destroy()
 
 Free resources and remove any listener.

--- a/js/src/SmartConnect/index.js
+++ b/js/src/SmartConnect/index.js
@@ -32,8 +32,8 @@ function smartConnect(publicAPI, model) {
   publicAPI.errorForwarder = (data, err) => {
     publicAPI.fireConnectionError(data, err);
   };
-  publicAPI.closeForwarder = (data) => {
-    publicAPI.fireConnectionClose(data);
+  publicAPI.closeForwarder = (data, err) => {
+    publicAPI.fireConnectionClose(data, err);
   };
 
   publicAPI.connect = () => {

--- a/js/src/WebsocketConnection/index.js
+++ b/js/src/WebsocketConnection/index.js
@@ -78,7 +78,7 @@ function WebsocketConnection(publicAPI, model) {
     };
 
     model.connection.onclose = (event) => {
-      publicAPI.fireConnectionClose(publicAPI);
+      publicAPI.fireConnectionClose(publicAPI, event);
       model.connection = null;
       // return !model.retry; // true => Stop retry
     };


### PR DESCRIPTION
The close event contains contents of the close frame sent by the server. The close frame is used by the server to inform of the connection setup problem.