### PR TITLE
enable heartbeat to shutdown clients on network interrupt

### DIFF
--- a/python/src/wslink/backends/aiohttp/__init__.py
+++ b/python/src/wslink/backends/aiohttp/__init__.py
@@ -217,7 +217,7 @@ class WslinkHandler(object):
         aiohttp_app = request.app
 
         client_id = str(uuid.uuid4()).replace("-", "")
-        current_ws = aiohttp_web.WebSocketResponse(max_msg_size=MAX_MSG_SIZE)
+        current_ws = aiohttp_web.WebSocketResponse(max_msg_size=MAX_MSG_SIZE, heartbeat=30)
         self.connections[client_id] = current_ws
 
         logging.info("client {0} connected".format(client_id))


### PR DESCRIPTION
When using vtk.js remoteView together with wslink and vtkWeb we run into websocket timeouts whenever a user doesn't interact for more than 60s. While not exactly sure who is responsible for interrupting the connection (apache, wslink) another side-effect of those interrupted sessions is that wslink does not shutdown these correctly.
Looking at the code wslink async awaits on new messages but in case of (forced) connection drop it basically hangs forever waiting for messages on a dead client.
While it would be possible to add ws ping to our client code it would only partially solve the issue of leaked sessions, it would keep connections alive but any network interruption would still lead to the issue described.
So the imho better approach would be to use the built in 'heartbeat' functionality of aiohttp which by default is deactivated.
The PR uses a (random) fixed number of 30s, which I guess could also come from a config but it wouldn't be needed as long as the heartbeat interval is below 60s.

