### PR TITLE
Add onConnect on onClose methods to ServerProtocol and LinkProtocol

### DIFF
--- a/python/src/wslink/backends/aiohttp/__init__.py
+++ b/python/src/wslink/backends/aiohttp/__init__.py
@@ -229,12 +229,12 @@ class WslinkHandler(object):
 
         await current_ws.prepare(request)
 
-        await self.onConnect()
+        await self.onConnect(request, client_id)
 
         async for msg in current_ws:
             await self.onMessage(msg, client_id)
 
-        await self.onClose()
+        await self.onClose(client_id)
 
         del self.connections[client_id]
 
@@ -246,11 +246,23 @@ class WslinkHandler(object):
 
         return current_ws
 
-    async def onConnect(self):
-        pass
+    async def onConnect(self, request, client_id):
+        if not self.serverProtocol:
+            return
+        if hasattr(self.serverProtocol, "onConnect"):
+            self.serverProtocol.onConnect(request, client_id)
+        for linkProtocol in self.serverProtocol.getLinkProtocols():
+            if hasattr(linkProtocol, "onConnect"):
+                linkProtocol.onConnect(request, client_id)
 
-    async def onClose(self):
-        pass
+    async def onClose(self, client_id):
+        if not self.serverProtocol:
+            return
+        if hasattr(self.serverProtocol, "onClose"):
+            self.serverProtocol.onClose(client_id)
+        for linkProtocol in self.serverProtocol.getLinkProtocols():
+            if hasattr(linkProtocol, "onClose"):
+                linkProtocol.onClose(client_id)
 
     async def handleSystemMessage(self, rpcid, methodName, args, client_id):
         rpcList = rpcid.split(":")

--- a/python/src/wslink/websocket.py
+++ b/python/src/wslink/websocket.py
@@ -39,6 +39,22 @@ class LinkProtocol(object):
             return self.coreServer.getSharedObject(key)
         return None
 
+    def onConnect(self, request, client_id):
+        """Called when a new websocket connection is established.
+
+        request is the HTTP request header, and client_id an opaque string that
+        identifies the connection.  The default implementation is a noop. A
+        subclass may redefine it.
+
+        """
+
+        pass
+
+    def onClose(self, client_id):
+        """Called when a websocket connection is closed.
+        """
+
+        pass
 
 # =============================================================================
 #
@@ -105,6 +121,23 @@ class ServerProtocol(object):
 
     def updateSecret(self, newSecret):
         self.secret = newSecret
+
+    def onConnect(self, request, client_id):
+        """Called when a new websocket connection is established.
+
+        request is the HTTP request header, and client_id an opaque string that
+        identifies the connection.  The default implementation is a noop. A
+        subclass may redefine it.
+
+        """
+
+        pass
+
+    def onClose(self, client_id):
+        """Called when a websocket connection is closed.
+        """
+
+        pass
 
     @exportRpc("application.exit")
     def exit(self):


### PR DESCRIPTION
onConnect(request, client_id) -> None
onClose(client_id) -> None

They are called when a websocket connection is established or closed.  Arg
request is the aiohttp HTTP request header. client_id is an opaque string that
identifies the connection.  onC

Our use case is use an HTTP cookie in the request header to authenticate the
request.

A clear and concise description of what the problem was and how this pull request solves it.

fix #ISSUE_NUMBER
