### PR TITLE
fix(python): downgrade the startup log message

### DIFF
--- a/python/src/wslink/backends/aiohttp/__init__.py
+++ b/python/src/wslink/backends/aiohttp/__init__.py
@@ -23,7 +23,7 @@ MAX_MSG_SIZE = int(os.environ.get("WSLINK_MAX_MSG_SIZE", 4194304))
 
 async def _on_startup(app):
     # Emit an expected log message so launcher.py knows we've started up.
-    logging.critical("wslink: Starting factory")
+    print("wslink: Starting factory")
     # We've seen some issues with stdout buffering - be conservative.
     sys.stdout.flush()
 


### PR DESCRIPTION
Downgrade the level of wslink startup message from critical to info.

A clear and concise description of what the problem was and how this pull request solves it.

fix #ISSUE_NUMBER
