### PR TITLE
doc(js): Add type definitions

### DIFF
--- a/js/src/SmartConnect/index.d.ts
+++ b/js/src/SmartConnect/index.d.ts
@@ -1,0 +1,62 @@
+import WebsocketConnection from '../WebsocketConneciot';
+
+export declare const DEFAULT_SESSION_MANAGER_URL: string;
+
+export interface ISmartConnectConfig {
+  // URL to connect to. E.g., "ws://localhost:1234".
+  sessionURL?: string;
+  // Endpoint of the launcher that is responsible to start the server process.
+  // Defaults to  SESSION_MANAGER_URL.
+  sessionManagerURL?: string;
+  // The secret token to be sent during handshake and validated by the server.
+  secret?: string;
+  retry?: number;
+}
+
+export interface ISmartConnectInitialValues {
+  config: ISmartConnectConfig;
+}
+
+export type Event = any;
+
+export interface WebsocketCloseEvent {
+  // This object reports the values of the close frame.  Cf. RFC6455 section
+  // 5.5.1. If the connection closes w/o a close frame, the following fields are unset.
+  code?: number // RFC6455, section 7.4.
+  reason?: string;
+}
+
+export interface SmartConnect {
+  // Starts connecting to the server.
+  connect(): void;
+  getSession(): WebSocket;
+  // Called when the connection is established
+  onConnectionReady(cb: (c: WebsocketConnection) => void): void;
+  // Called when the connection cannot be established.
+  onConnectionError(cb: (c: WebsocketConnection, err: Event) => void): void;
+  // Called when the connection is closed.
+  onConnectionClose(cb: (c: WebsocketConnection, event: WebsocketCloseEvent) => void): void;
+  // Close the connection and destroy this object.
+  destroy(): void;
+  // Return the config passed to newInstance.
+  getConfig(): ISmartConnectConfig;
+  getConfigDecorator(): any;
+  setConfigDecorator(c: any): void;
+}
+
+/**
+ * Creates a new SmartConnect object with the given configuration.
+ */
+dexport function newInstance(config: ISmartConnectInitialValues): SmartConnect;
+
+/**
+ * Decorates a given object (publicAPI+model) with SmartConnect characteristics.
+ */
+export function extend(publicAPI: object, model: object, initialValues?: ISmartConnectInitialValues): void;
+
+export declare const SmartConnect: {
+  newInstance: typeof newInstance;
+  extend: typeof extend;
+}
+
+export default SmartConnect;

--- a/js/src/WebsocketConnection/index.d.ts
+++ b/js/src/WebsocketConnection/index.d.ts
@@ -1,0 +1,44 @@
+
+export interface SubscriberId { topic: string }
+
+// Provides a generic RPC stub built on top of websocket.
+export interface WebsocketSession {
+  // Issue a single-shot RPC.
+  call(methodName: string, args: any[]): Promise<any>;
+  // Subscribe to one-way messages from the server.
+  subscribe(methodName: string, callback: (args: any[]) => Promise<any>): Promise<SubscriberId>;
+  // Cancel an existing subscription.
+  unsubscribe(id: SubscriberId): Promise<void>;
+  close(): void;
+}
+
+export interface IWebsocketConnectionInitialValues {
+  secret?: string;
+  connection?: any;
+  session?: any;
+  retry?: boolean;
+}
+
+// Represents a single established websocket connection.
+export interface WebsocketConnection {
+  getSession(): WebsocketSession;
+  getUrl(): string | null;
+  destroy(): void;
+}
+
+/**
+ * Creates a new SmartConnect object with the given configuration.
+ */
+export function newInstance(initialValues: IWebsocketConnectionInitialValues): WebsocketConnection;
+
+/**
+ * Decorates a given object (publicAPI+model) with WebsocketConnection characteristics.
+ */
+export function extend(publicAPI: object, model: object, initialValues?: IWebsocketConnectionInitialValues): void;
+
+export declare const WebSocketConnection: {
+  newInstance: typeof newInstance;
+  extend: typeof extend;
+}
+
+export default WebSocketConnection;


### PR DESCRIPTION
Add typescript definitions for SmartConnect and WebsocketConnection.  They cover
most, not all, of the commonly used types.

A clear and concise description of what the problem was and how this pull request solves it.

fix #ISSUE_NUMBER
