### PR TITLE
feat(timeout): allow server without shutdown timeout

### DIFF
--- a/python/src/wslink/backends/aiohttp/__init__.py
+++ b/python/src/wslink/backends/aiohttp/__init__.py
@@ -34,7 +34,11 @@ async def _on_startup(app):
 
 def _schedule_shutdown(app):
     timeout = app["state"]["server_config"]["timeout"]
-    app["state"]["shutdown_task"] = schedule_coroutine(timeout, _stop_server, app)
+    app["state"]["shutdown_task"] = (
+        schedule_coroutine(timeout, _stop_server, app)
+        if timeout > 0
+        else None
+    )
 
 
 async def _root_handler(request):

--- a/python/src/wslink/server.py
+++ b/python/src/wslink/server.py
@@ -63,7 +63,7 @@ def add_arguments(parser):
         "--timeout",
         type=int,
         default=300,
-        help="timeout for reaping process on idle in seconds (default: 300s)",
+        help="timeout for reaping process on idle in seconds (default: 300s, 0 to disable)",
     )
     parser.add_argument(
         "-c",


### PR DESCRIPTION
Allow to pass a value of 0 to timeout for wslink server, to disable the automatic shutdown.

fix #97
