### PR TITLE
Fix DEFAULT_SESSION_URL construction

### DIFF
--- a/js/src/SmartConnect/index.js
+++ b/js/src/SmartConnect/index.js
@@ -29,7 +29,7 @@ function extractPathName(addOn, pathName=window.location.pathname) {
 
 export const DEFAULT_SESSION_MANAGER_URL = `${window.location.protocol}//${window.location.hostname}:${window.location.port}/paraview/`,
   DEFAULT_SESSION_URL = `${
-    window.location.protocol === 'https' ? 'wss' : 'ws'
+    window.location.protocol === 'https:' ? 'wss' : 'ws'
   }://${window.location.hostname}:${window.location.port}${extractPathName('/ws')}`;
 
 function wsConnect(publicAPI, model) {


### PR DESCRIPTION
The value of window.location.protocol ends with ':'