### PR TITLE
fix(js): Properly handle protocol mapping

### DIFF
--- a/js/src/SmartConnect/index.js
+++ b/js/src/SmartConnect/index.js
@@ -29,7 +29,7 @@ function extractPathName(addOn, pathName=window.location.pathname) {
 
 export const DEFAULT_SESSION_MANAGER_URL = `${window.location.protocol}//${window.location.hostname}:${window.location.port}/paraview/`,
   DEFAULT_SESSION_URL = `${
-    window.location.protocol === 'https' ? 'wss' : 'ws'
+    window.location.protocol === 'https:' ? 'wss' : 'ws'
   }://${window.location.hostname}:${window.location.port}${extractPathName('/ws')}`;
 
 function wsConnect(publicAPI, model) {


### PR DESCRIPTION
The value of window.location.protocol ends with ':'.

I didn't know how to rename properly, so I had to start over.
Thanks for the advice.

