### PR TITLE
docs(types): add optional kwargs parameter to WebsocketSession.call signature

### DIFF
--- a/js/src/WebsocketConnection/index.d.ts
+++ b/js/src/WebsocketConnection/index.d.ts
@@ -6,7 +6,7 @@ export interface SubscriberInfo {
 // Provides a generic RPC stub built on top of websocket.
 export interface WebsocketSession {
   // Issue a single-shot RPC.
-  call(methodName: string, args: any[]): Promise<any>;
+  call(methodName: string, args?: any[], kwargs?: Record<string, any>): Promise<any>;
   // Subscribe to one-way messages from the server.
   subscribe(topic: string, callback: (args: any[]) => Promise<any>): {
     // A promise to be resolved once subscription succeeds.


### PR DESCRIPTION
Correct typescript signature of the `WebsocketSession.call` method,
adding the accepted optional `kwargs` parameter.