### PR TITLE
MAINT: Avoid newer, breaking versions of aiohttp

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp>=3.7.4
+aiohttp>=3.7.4,<4
 
 # platform specific
 pypiwin32==223; sys_platform == 'win32'

--- a/python/setup.py
+++ b/python/setup.py
@@ -45,6 +45,6 @@ setup(
     keywords="websocket javascript rpc pubsub",
     packages=find_packages("src", exclude=("tests.*", "tests")),
     package_dir={"": "src"},
-    install_requires=["aiohttp"],
+    install_requires=["aiohttp<4"],
     include_package_data=True,
 )


### PR DESCRIPTION
Hi,

I originally opened this vtk issue - https://gitlab.kitware.com/vtk/vtk/-/issues/18591

Essentially, installing vtk (and as a result, wslink) with `pip install --pre` leads to https://github.com/aio-libs/aiohttp/issues/6799.

This goes around the problem by avoid the 4.x series of aiohttp, which may introduce breaking changes and is still not stable.