### PR TITLE
Support SSL context 

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -46,5 +46,8 @@ setup(
     packages=find_packages("src", exclude=("tests.*", "tests")),
     package_dir={"": "src"},
     install_requires=["aiohttp<4"],
+    extras_require={
+        "ssl": ["cryptography"],
+    },
     include_package_data=True,
 )

--- a/python/src/wslink/backends/aiohttp/__init__.py
+++ b/python/src/wslink/backends/aiohttp/__init__.py
@@ -102,6 +102,7 @@ class AiohttpWslinkServer(object):
         port = int(self.config["port"])
         timeout = int(self.config["timeout"])
         handle_signals = self.config["handle_signals"]
+        ssl_context = self.config.get("ssl", None)
 
         runner = aiohttp_web.AppRunner(app, handle_signals=handle_signals)
         loop = asyncio.get_event_loop()
@@ -113,7 +114,7 @@ class AiohttpWslinkServer(object):
         logging.info("awaiting runner setup")
         await runner.setup()
 
-        my_site = aiohttp_web.TCPSite(runner, host, port)
+        my_site = aiohttp_web.TCPSite(runner, host, port, ssl_context=ssl_context)
 
         logging.info("awaiting site startup")
         await my_site.start()

--- a/python/src/wslink/ssl_context.py
+++ b/python/src/wslink/ssl_context.py
@@ -1,0 +1,68 @@
+import ssl
+
+
+def load_ssl_context(cert_file, pkey_file):
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(cert_file, pkey_file)
+    return context
+
+
+def save_ssl_files(cert, pkey):
+    import atexit
+    import os
+    import tempfile
+    from cryptography.hazmat.primitives import serialization
+
+    cert_handle, cert_file = tempfile.mkstemp()
+    pkey_handle, pkey_file = tempfile.mkstemp()
+    atexit.register(os.remove, pkey_file)
+    atexit.register(os.remove, cert_file)
+
+    os.write(cert_handle, cert.public_bytes(serialization.Encoding.PEM))
+    os.write(
+        pkey_handle,
+        pkey.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption(),
+        ),
+    )
+
+    os.close(cert_handle)
+    os.close(pkey_handle)
+    return cert_file, pkey_file
+
+
+def generate_ssl_pair(host):
+    try:
+        from cryptography import x509
+        from cryptography.x509.oid import NameOID
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        import datetime
+    except ImportError:
+        raise TypeError(
+            "Using ad-hoc certificates requires the cryptography library."
+        ) from None
+    cn = f"*.{host}/CN={host}"
+    pkey = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name(
+        [
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Dummy Certificate"),
+            x509.NameAttribute(NameOID.COMMON_NAME, cn),
+        ]
+    )
+    one_day = datetime.timedelta(1, 0, 0)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(pkey.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime.today() - one_day)
+        .not_valid_after(datetime.datetime.today() + (one_day * 365))
+        .add_extension(x509.ExtendedKeyUsage([x509.OID_SERVER_AUTH]), critical=False)
+        .add_extension(x509.SubjectAlternativeName([x509.DNSName(cn)]), critical=False)
+        .sign(private_key=pkey, algorithm=hashes.SHA256())
+    )
+    return save_ssl_files(cert, pkey)


### PR DESCRIPTION
On some cloud platforms (here AWS), we need the ssl/wss protocol to be used. 
aiohttp is able to handle such connexion but it was not accessible from the wslink API.

We also added the ability to create a temporary certificate.

fix #112 
