### PR TITLE
feat(security): Added authKeyFile argument

### DIFF
--- a/python/src/wslink/server.py
+++ b/python/src/wslink/server.py
@@ -35,7 +35,10 @@ def add_arguments(parser):
     """
 
     parser.add_argument(
-        "-d", "--debug", help="log debugging messages to stdout", action="store_true"
+        "-d",
+        "--debug",
+        help="log debugging messages to stdout",
+        action="store_true"
     )
     parser.add_argument(
         "-s",
@@ -83,6 +86,10 @@ def add_arguments(parser):
         default="ws",
         dest="ws",
         help="Specify WebSocket endpoint. (e.g. foo/bar/ws, Default: ws)",
+    )
+    parser.add_argument(
+        "--authKeyFile",
+        help="Path to a File that contains the Authentication key for clients to connect to the WebSocket."
     )
     parser.add_argument(
         "--no-ws-endpoint",


### PR DESCRIPTION
On most multi-user setups, command line arguments [can be viewed by anyone on that system](https://unix.stackexchange.com/questions/8223/can-other-users-view-the-arguments-passed-to-a-command). Passing the authKey via a command line argument can be a security flaw.

Allowing the user to pass the path to a file instead will eliminate that problem. Using a tempfile that can only be read by the user, we can safely pass the authKey without the possibility of a third party reading it.

I added the `authKeyFile` option, that allows for exactly that.