### PR TITLE
fix(gracefulexit): handle server exit for exec_mode=main

### DIFF
--- a/python/src/wslink/server.py
+++ b/python/src/wslink/server.py
@@ -279,11 +279,12 @@ def start_webserver(
         return ws_server.start(port_callback)
 
     def main_exec():
-        # Block until the loop finishes and then close the loop
+        # Block until webapp exits
         try:
             loop.run_until_complete(create_coroutine())
-        finally:
-            loop.close()
+        except SystemExit:
+            # backend gracefully exit (due to timeout or SIGINT/SIGTERM)
+            pass
 
     def task_exec():
         return loop.create_task(create_coroutine())


### PR DESCRIPTION
- Handle backend exit exception instead of letting it propagate to application level. The `aiohttp` backend raises `GracefulExit` a subclass of `SystemExit`. This code assumes any other backend would similarly raise a `SystemExit` derived exception.

- To achieve the above, the event loop must not be closed. Besides, calling code may want to schedule application clean up after server connection is closed.
