### PR TITLE
fix RPC call application.exit.later unsuccessful: connection not open

### DIFF
--- a/js/src/SmartConnect/index.js
+++ b/js/src/SmartConnect/index.js
@@ -134,8 +134,9 @@ function smartConnect(publicAPI, model) {
     return session;
   };
 
-  function cleanUp() {
+  function cleanUp(timeout) {
     if (session) {
+      timeout > 0 && session.call('application.exit.later', [timeout]);
       session.close();
     }
     session = null;

--- a/js/src/WebsocketConnection/index.js
+++ b/js/src/WebsocketConnection/index.js
@@ -105,7 +105,7 @@ function WebsocketConnection(publicAPI, model) {
     model.connection ? model.connection.url : undefined;
 
   function cleanUp(timeout = 10) {
-    if (model.session && timeout > 0) {
+    if (model.connection.readyState === 1 && model.session && timeout > 0) {
       model.session.call('application.exit.later', [timeout]);
     }
     if (model.connection) {


### PR DESCRIPTION
add come compatible code