### PR TITLE
fix(unchunker): initial allowed message size to env var

### DIFF
--- a/python/src/wslink/chunking.py
+++ b/python/src/wslink/chunking.py
@@ -87,7 +87,7 @@ class UnChunker:
 
     def __init__(self):
         self.pending_messages = {}
-        self.max_message_size = 512
+        self.max_message_size = 3000
 
     def set_max_message_size(self, size):
         self.max_message_size = size

--- a/python/src/wslink/chunking.py
+++ b/python/src/wslink/chunking.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import secrets
 import msgpack
@@ -87,7 +88,7 @@ class UnChunker:
 
     def __init__(self):
         self.pending_messages = {}
-        self.max_message_size = 3000
+        self.max_message_size = int(os.environ.get("WSLINK_AUTH_MSG_SIZE", 512))
 
     def set_max_message_size(self, size):
         self.max_message_size = size


### PR DESCRIPTION
When sending a JWT token along with a message, this size ends up too small and results in a ValueError. This PR increases max_message_size to 3000 to accommodate.

fix #157 
