### PR TITLE
fix: fix type hints for python < 3.10 on aiohttp backend

### DIFF
--- a/python/src/wslink/backends/aiohttp/__init__.py
+++ b/python/src/wslink/backends/aiohttp/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 import logging
 import sys
@@ -6,6 +7,7 @@ import json
 from pathlib import Path
 
 from wslink.protocol import WslinkHandler, AbstractWebApp
+
 
 # Backend specific imports
 import aiohttp


### PR DESCRIPTION
- Fix #159 

If adding the `__future__`  import is the way you want to go, here it is. Feel free to close if you want to go another direction.

A simple test importing `from wslink.backends import aiohttp` confirms the fix.
