### PR TITLE
feat(protocol): log internal events through an object that can be subscribed to

### DIFF
--- a/python/src/wslink/backends/generic/core.py
+++ b/python/src/wslink/backends/generic/core.py
@@ -56,7 +56,7 @@ class WsConnection:
 
 
 class WsEndpoint(WslinkHandler):
-    def __init__(self, protocol=None, web_app=None):
+    def __init__(self, protocol, web_app=None):
         super().__init__(protocol, web_app)
 
     async def connect(self):

--- a/python/src/wslink/backends/jupyter/core.py
+++ b/python/src/wslink/backends/jupyter/core.py
@@ -1,47 +1,7 @@
-import asyncio
 from functools import partial
+from wslink.emitter import EventEmitter
 from wslink.backends.generic.core import GenericServer
 from IPython.core.getipython import get_ipython
-
-
-class EventEmitter:
-    def __init__(self):
-        self._listeners = {}
-
-    def clear(self):
-        self._listeners = {}
-
-    def emit(self, event, *args, **kwargs):
-        listeners = self._listeners.get(event)
-        if listeners is None:
-            return
-
-        loop = asyncio.get_running_loop()
-        coroutine_run = (
-            loop.create_task if (loop and loop.is_running()) else asyncio.run
-        )
-
-        for listener in listeners:
-            if asyncio.iscoroutinefunction(listener):
-                coroutine_run(listener(*args, **kwargs))
-            else:
-                listener(*args, **kwargs)
-
-    def add_event_listener(self, event, listener):
-        listeners = self._listeners.get(event)
-        if listeners is None:
-            listeners = set()
-            self._listeners[event] = listeners
-
-        listeners.add(listener)
-
-    def remove_event_listener(self, event, listener):
-        listeners = self._listeners.get(event)
-        if listeners is None:
-            return
-
-        if listener in listeners:
-            listeners.remove(listener)
 
 
 class WsJupyterComm(EventEmitter):

--- a/python/src/wslink/emitter.py
+++ b/python/src/wslink/emitter.py
@@ -1,0 +1,63 @@
+from typing import TypeVar, Generic, LiteralString
+
+import asyncio
+import functools
+
+
+T = TypeVar("T", bound=LiteralString)
+
+
+class EventEmitter(Generic[T]):
+    def __init__(self):
+        self._listeners = {}
+
+    def clear(self):
+        self._listeners = {}
+
+    def __call__(self, event: T, *args, **kwargs):
+        self.emit(event, *args, **kwargs)
+
+    def __getattr__(self, name: T):
+        return functools.partial(self.emit, name)
+
+    def emit(self, event: T, *args, **kwargs):
+        listeners = self._listeners.get(event)
+        if listeners is None:
+            return
+
+        loop = asyncio.get_running_loop()
+        coroutine_run = (
+            loop.create_task if (loop and loop.is_running()) else asyncio.run
+        )
+
+        for listener in listeners:
+            if asyncio.iscoroutinefunction(listener):
+                coroutine_run(listener(*args, **kwargs))
+            else:
+                listener(*args, **kwargs)
+
+    def add_event_listener(self, event: T, listener):
+        listeners = self._listeners.get(event)
+        if listeners is None:
+            listeners = set()
+            self._listeners[event] = listeners
+
+        listeners.add(listener)
+
+    def remove_event_listener(self, event: T, listener):
+        listeners = self._listeners.get(event)
+        if listeners is None:
+            return
+
+        if listener in listeners:
+            listeners.remove(listener)
+
+    def has(self, event: T):
+        return self.listeners_count(event) > 0
+
+    def listeners_count(self, event: T):
+        listeners = self._listeners.get(event)
+        if listeners is None:
+            return 0
+
+        return len(listeners)


### PR DESCRIPTION
Internal messages within the wslink protocol are published on an object that clients can subscribe to.

Example usage in trame:
```python
def handle_errors(self, message: str):
    pass

def handle_exceptions(self, e: Exception):
    pass

server.protocol.log_emitter.add_event_listener("error", handle_errors)
server.protocol.log_emitter.add_event_listener("exception", handle_exceptions)
```